### PR TITLE
chore: scaffold Tailwind-aware HTML editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# htmlEditor
+# Tailwind-Aware Visual HTML Editor
+
+This project is a proof-of-concept single-page application for visually editing
+HTML files styled with Tailwind CSS. Users can upload an HTML document, preview
+it in a sandboxed iframe, select elements, and inspect their Tailwind classes.
+
+## Development
+
+The application uses **React**, **TypeScript**, **Zustand** for state
+management, and **Tailwind CSS** for styling. **Vite** provides the build
+tooling.
+
+### Available Scripts
+
+- `npm run dev` – start the development server
+- `npm run build` – build for production
+- `npm test` – run tests (placeholder)
+- `npm run generate:manifest` – generate `tailwind-manifest.json` (placeholder)
+
+## Notes
+
+This repository currently contains a minimal, non-functioning skeleton intended
+to illustrate the architecture described in the specification. Many features,
+including style computation and class mutation, remain to be implemented.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tailwind-Aware HTML Editor</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "tailwind-aware-html-editor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "generate:manifest": "ts-node scripts/generateManifest.ts",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "interactjs": "^1.10.17",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.4.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.3",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9",
+    "vitest": "^0.34.3",
+    "@vitejs/plugin-react": "^4.0.4"
+  }
+}
+

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+

--- a/scripts/generateManifest.ts
+++ b/scripts/generateManifest.ts
@@ -1,0 +1,28 @@
+/**
+ * Placeholder script for generating a Tailwind manifest.
+ * In a production environment, this would parse Tailwind's output and
+ * collect all utility classes with their corresponding CSS declarations.
+ */
+import fs from 'fs';
+
+function generateManifest() {
+  const manifest = {
+    spacing: {
+      margin: {
+        'mt-4': 'margin-top: 1rem;',
+      },
+      padding: {
+        'p-4': 'padding: 1rem;',
+      },
+    },
+    colors: {
+      'text-blue-500': 'color: #3b82f6;',
+    },
+  };
+
+  fs.writeFileSync('tailwind-manifest.json', JSON.stringify(manifest, null, 2));
+  console.log('tailwind-manifest.json generated');
+}
+
+generateManifest();
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,92 @@
+import React, { useCallback } from 'react';
+import { SandboxIframe } from './components/SandboxIframe';
+import { PropertyInspector } from './components/PropertyInspector';
+import { useStore } from './state/useStore';
+import { TailwindStyleObject, ClassMutationCommand } from './types';
+
+const App: React.FC = () => {
+  const {
+    htmlContent,
+    setHtmlContent,
+    setSelectedElement,
+    computedStyles,
+    setComputedStyles,
+  } = useStore();
+
+  const handleFileUpload = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        setHtmlContent(String(reader.result));
+      };
+      reader.readAsText(file);
+    },
+    [setHtmlContent]
+  );
+
+  const handleElementSelect = useCallback(
+    (el: HTMLElement) => {
+      setSelectedElement(el);
+      // Placeholder style computation: simply list classes under layout
+      const styles: TailwindStyleObject = {
+        layout: {},
+        spacing: {},
+        typography: {},
+        backgrounds: {},
+        borders: {},
+        effects: {},
+      };
+      el.className.split(' ').forEach((cls) => {
+        if (cls) styles.layout[cls] = '';
+      });
+      setComputedStyles(styles);
+    },
+    [setSelectedElement, setComputedStyles]
+  );
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([htmlContent], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'edited.html';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [htmlContent]);
+
+  const handleClassChange = useCallback((command: ClassMutationCommand) => {
+    // TODO: Implement Class Mutator Engine
+    console.log('class change', command);
+  }, []);
+
+  return (
+    <div className="flex h-screen">
+      <div className="flex flex-col w-2/3 border-r">
+        <div className="p-2 flex gap-2 border-b">
+          <input type="file" accept=".html" onChange={handleFileUpload} />
+          <button
+            className="px-2 py-1 bg-blue-500 text-white rounded"
+            onClick={handleDownload}
+          >
+            Download
+          </button>
+        </div>
+        <SandboxIframe
+          htmlContent={htmlContent}
+          onElementSelect={handleElementSelect}
+        />
+      </div>
+      <div className="w-1/3">
+        <PropertyInspector
+          styles={computedStyles}
+          onClassChange={handleClassChange}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default App;
+

--- a/src/components/PropertyInspector.tsx
+++ b/src/components/PropertyInspector.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { TailwindStyleObject, ClassMutationCommand } from '../types';
+
+interface Props {
+  styles: TailwindStyleObject | null;
+  onClassChange: (command: ClassMutationCommand) => void;
+}
+
+/**
+ * Read-only placeholder property inspector.
+ * Displays the computed Tailwind style object as JSON.
+ */
+export const PropertyInspector: React.FC<Props> = ({ styles }) => {
+  if (!styles) {
+    return <div className="p-4 text-sm">No element selected</div>;
+  }
+
+  return (
+    <div className="p-4 text-xs overflow-y-auto h-full">
+      <pre>{JSON.stringify(styles, null, 2)}</pre>
+    </div>
+  );
+};
+

--- a/src/components/SandboxIframe.tsx
+++ b/src/components/SandboxIframe.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useRef } from 'react';
+
+interface Props {
+  htmlContent: string;
+  onElementSelect: (element: HTMLElement) => void;
+}
+
+export const SandboxIframe: React.FC<Props> = ({ htmlContent, onElementSelect }) => {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  // Update the iframe content whenever htmlContent changes
+  useEffect(() => {
+    if (iframeRef.current) {
+      iframeRef.current.srcdoc = htmlContent;
+    }
+  }, [htmlContent]);
+
+  // Attach click listener inside the iframe for element selection
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    const handleClick = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onElementSelect(e.target as HTMLElement);
+    };
+
+    const onLoad = () => {
+      const doc = iframe.contentDocument;
+      if (doc) {
+        doc.addEventListener('click', handleClick);
+      }
+    };
+
+    iframe.addEventListener('load', onLoad);
+    return () => {
+      iframe.removeEventListener('load', onLoad);
+      const doc = iframe.contentDocument;
+      doc?.removeEventListener('click', handleClick);
+    };
+  }, [onElementSelect]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      sandbox="allow-scripts allow-same-origin"
+      className="w-full flex-1"
+      title="sandbox"
+    />
+  );
+};
+

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,4 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+

--- a/src/state/useStore.ts
+++ b/src/state/useStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import { TailwindStyleObject } from '../types';
+
+interface AppState {
+  htmlContent: string;
+  selectedElement: HTMLElement | null;
+  computedStyles: TailwindStyleObject | null;
+  setHtmlContent: (html: string) => void;
+  setSelectedElement: (el: HTMLElement | null) => void;
+  setComputedStyles: (styles: TailwindStyleObject | null) => void;
+}
+
+export const useStore = create<AppState>((set) => ({
+  htmlContent: '',
+  selectedElement: null,
+  computedStyles: null,
+  setHtmlContent: (html) => set({ htmlContent: html }),
+  setSelectedElement: (el) => set({ selectedElement: el }),
+  setComputedStyles: (styles) => set({ computedStyles: styles }),
+}));
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,26 @@
+/**
+ * โครงสร้างสำหรับเก็บข้อมูลสไตล์ที่ประมวลผลจาก Tailwind classes
+ */
+export interface TailwindStyleObject {
+  layout: { [key: string]: string };
+  spacing: { [key: string]: string };
+  typography: { [key: string]: string };
+  backgrounds: { [key: string]: string };
+  borders: { [key: string]: string };
+  effects: { [key: string]: string };
+  // ... etc.
+}
+
+/**
+ * โครงสร้างสำหรับคำสั่งแก้ไข class list
+ */
+export interface ClassMutationCommand {
+  action: 'add' | 'remove' | 'replace';
+  /** The class to be replaced. Required for 'replace' action. */
+  oldClass?: string;
+  /** The new class to be added or to replace the old one. */
+  newClass: string;
+  /** The category of the class, e.g., 'margin-top'. Used for conflict resolution. */
+  category: string;
+}
+

--- a/tailwind-manifest.json
+++ b/tailwind-manifest.json
@@ -1,0 +1,14 @@
+{
+  "spacing": {
+    "margin": {
+      "mt-4": "margin-top: 1rem;"
+    },
+    "padding": {
+      "p-4": "padding: 1rem;"
+    }
+  },
+  "colors": {
+    "text-blue-500": "color: #3b82f6;"
+  }
+}
+

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "scripts"]
+}
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Vite configuration for the Tailwind-Aware Visual HTML Editor
+export default defineConfig({
+  plugins: [react()],
+});
+


### PR DESCRIPTION
## Summary
- initialize Vite + React + TypeScript scaffold with Tailwind, Zustand, and placeholder manifest script
- add sandboxed iframe component and read-only property inspector for selected elements
- document usage and scripts in README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run generate:manifest` *(fails: ts-node not found)*
- `npm run build` *(fails: Cannot find module 'fs' and missing React/Zustand types)*

------
https://chatgpt.com/codex/tasks/task_e_68981e2913f8832ca0a1822ba2e3b07a