### PR TITLE
Enable editable sandbox and text modifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,7 @@ const App: React.FC = () => {
         <SandboxIframe
           htmlContent={htmlContent}
           onElementSelect={handleElementSelect}
+          onHtmlChange={setHtmlContent}
         />
       </div>
       <div className="w-1/3">

--- a/src/components/PropertyInspector.tsx
+++ b/src/components/PropertyInspector.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { TailwindStyleObject, ClassMutationCommand } from '../types';
+import { useStore } from '../state/useStore';
 
 interface Props {
   styles: TailwindStyleObject | null;
@@ -7,16 +8,50 @@ interface Props {
 }
 
 /**
- * Read-only placeholder property inspector.
- * Displays the computed Tailwind style object as JSON.
+ * Basic property inspector.
+ * Allows editing of text content and displays the computed Tailwind style object.
  */
 export const PropertyInspector: React.FC<Props> = ({ styles }) => {
+  const selectedElement = useStore((state) => state.selectedElement);
+  const setHtmlContent = useStore((state) => state.setHtmlContent);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    if (selectedElement) {
+      setText(selectedElement.textContent || '');
+    } else {
+      setText('');
+    }
+  }, [selectedElement]);
+
   if (!styles) {
     return <div className="p-4 text-sm">No element selected</div>;
   }
 
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newText = e.target.value;
+    setText(newText);
+    if (selectedElement) {
+      selectedElement.textContent = newText;
+      const doc = selectedElement.ownerDocument;
+      if (doc) {
+        setHtmlContent(doc.documentElement.outerHTML);
+      }
+    }
+  };
+
   return (
     <div className="p-4 text-xs overflow-y-auto h-full">
+      {selectedElement && (
+        <div className="mb-4">
+          <label className="block mb-1">Text Content</label>
+          <textarea
+            className="w-full border p-1"
+            value={text}
+            onChange={handleTextChange}
+          />
+        </div>
+      )}
       <pre>{JSON.stringify(styles, null, 2)}</pre>
     </div>
   );

--- a/src/components/SandboxIframe.tsx
+++ b/src/components/SandboxIframe.tsx
@@ -3,15 +3,24 @@ import React, { useEffect, useRef } from 'react';
 interface Props {
   htmlContent: string;
   onElementSelect: (element: HTMLElement) => void;
+  onHtmlChange: (html: string) => void;
 }
 
-export const SandboxIframe: React.FC<Props> = ({ htmlContent, onElementSelect }) => {
+export const SandboxIframe: React.FC<Props> = ({
+  htmlContent,
+  onElementSelect,
+  onHtmlChange,
+}) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   // Update the iframe content whenever htmlContent changes
   useEffect(() => {
     if (iframeRef.current) {
-      iframeRef.current.srcdoc = htmlContent;
+      const doc = iframeRef.current.contentDocument;
+      const current = doc?.documentElement.outerHTML;
+      if (current !== htmlContent) {
+        iframeRef.current.srcdoc = htmlContent;
+      }
     }
   }, [htmlContent]);
 
@@ -26,10 +35,21 @@ export const SandboxIframe: React.FC<Props> = ({ htmlContent, onElementSelect })
       onElementSelect(e.target as HTMLElement);
     };
 
+    const handleInput = () => {
+      const doc = iframe.contentDocument;
+      if (doc) {
+        onHtmlChange(doc.documentElement.outerHTML);
+      }
+    };
+
     const onLoad = () => {
       const doc = iframe.contentDocument;
       if (doc) {
         doc.addEventListener('click', handleClick);
+        doc.addEventListener('input', handleInput);
+        if (doc.body) {
+          doc.body.contentEditable = 'true';
+        }
       }
     };
 
@@ -38,8 +58,9 @@ export const SandboxIframe: React.FC<Props> = ({ htmlContent, onElementSelect })
       iframe.removeEventListener('load', onLoad);
       const doc = iframe.contentDocument;
       doc?.removeEventListener('click', handleClick);
+      doc?.removeEventListener('input', handleInput);
     };
-  }, [onElementSelect]);
+  }, [onElementSelect, onHtmlChange]);
 
   return (
     <iframe


### PR DESCRIPTION
## Summary
- allow editing HTML content directly inside the sandbox iframe and sync changes to app state
- add text editor in property inspector to modify selected element content

## Testing
- `npm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68982b4fa81c832cb157560abd4e6ebf